### PR TITLE
SVCPLAN-3447 - Restrict kerberos-adm (port 749) access to certain subnets

### DIFF
--- a/manifests/primary/firewall.pp
+++ b/manifests/primary/firewall.pp
@@ -5,15 +5,26 @@
 #
 class profile_kerberos_server::primary::firewall {
 
-  # This should be kadmin and kpasswd
+  # kpasswd
   ['tcp','udp'].each |$protocol| {
-
-    firewall { "212 Kerberos via ${protocol}":
+    firewall { "212 kpasswd ${protocol}":
       proto  => $protocol,
-      dport  => [
-        '464',
-        '749',
-      ],
+      dport  => '464',
+      action => 'accept',
+    }
+  }
+
+  # kadmin
+  [
+    '141.142.0.0/16',
+    '10.142.0.0/16',
+    '172.24.0.0/13',
+    '172.16.0.0/13'
+  ].each |$range| {
+    firewall { "213 kerberos-adm tcp ${range}":
+      source => $range,
+      proto  => 'tcp',
+      dport  => '749',
       action => 'accept',
     }
   }


### PR DESCRIPTION
Restrict kerberos-adm (port 749) access to certain subnets